### PR TITLE
Include OpenStack builder task and ensure Hyper-V service is disabled

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -28,6 +28,9 @@
 - include_tasks: googlecompute.yml
   when: packer_builder_type.startswith('googlecompute')
 
+- include_tasks: openstack.yml
+  when: packer_builder_type.startswith('openstack')
+
 - include_tasks: oci.yml
   when: packer_builder_type.startswith('oracle-oci')
 

--- a/images/capi/ansible/roles/providers/tasks/openstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/openstack.yml
@@ -1,0 +1,33 @@
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Install cloud-init packages
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: yes
+  vars:
+    packages:
+    - cloud-init
+    - cloud-guest-utils
+    - cloud-initramfs-copymods
+    - cloud-initramfs-dyn-netconf
+  when: ansible_os_family == "Debian"
+
+- name: Disable Hyper-V KVP protocol daemon on Ubuntu
+  systemd:
+    name: hv-kvp-daemon
+    state: stopped
+    enabled: false
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
There were no Hyper-V roles where this service is disabled being included, due to how they're being looked-up for inclusion i.e off the Packer builder name.

This commit copies and trims the QEMU task and explicitly refers to it so that it's included in our builds on OpenStack.